### PR TITLE
Protected URLs were not validated correctly if the querystring value required URL encoding

### DIFF
--- a/TPR.UrlProtection.Tests/UrlProtectorTests.cs
+++ b/TPR.UrlProtection.Tests/UrlProtectorTests.cs
@@ -18,6 +18,19 @@ namespace TPR.UrlProtection.Tests
             Assert.That(protector.CheckProtectedPathAndQuery(url, salt), Is.True);
         }
 
+        [TestCase(ParameterLocation.Path)]
+        [TestCase(ParameterLocation.Query)]
+        public void UnalteredUrlRequiringUrlEncodingIsAllowed(ParameterLocation parameterLocation)
+        {
+            var url = new Uri("https://www.example.org/protect-me?thing=test with spaces");
+            var salt = Guid.NewGuid().ToString();
+            var protector = CreateProtector(parameterLocation);
+
+            url = protector.ProtectPathAndQuery(url, salt);
+
+            Assert.That(protector.CheckProtectedPathAndQuery(url, salt), Is.True);
+        }
+
         private static UrlProtector CreateProtector(ParameterLocation parameterLocation)
         {
             if (parameterLocation == ParameterLocation.Path)

--- a/TPR.UrlProtection/TPR.UrlProtection.csproj
+++ b/TPR.UrlProtection/TPR.UrlProtection.csproj
@@ -20,6 +20,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Company>The Pensions Regulator</Company>
     <Authors>rickmason-tpr</Authors>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TPR.UrlProtection/UrlProtector.cs
+++ b/TPR.UrlProtection/UrlProtector.cs
@@ -31,7 +31,7 @@ namespace TPR.UrlProtection
             var query = HttpUtility.ParseQueryString(urlToProtect.Query ?? string.Empty);
 
             // Hash the URI and add it as a parameter
-            query.Add(HashParameter, CreateUrlHash(urlToProtect.AbsolutePath + urlToProtect.Query?.TrimStart('?'), salt));
+            query.Add(HashParameter, CreateUrlHash(urlToProtect.AbsolutePath + query, salt));
             var urlWithProtection = new Uri(urlToProtect.Scheme + "://" + urlToProtect.Authority + urlToProtect.AbsolutePath + "?" + query, UriKind.Absolute);
 
             if (ParameterLocation == ParameterLocation.Query)
@@ -73,7 +73,7 @@ namespace TPR.UrlProtection
             {
                 if (name == HashParameter) { continue; }
                 if (protectedQueryString.Length > 0) { protectedQueryString.Append("&"); }
-                protectedQueryString.Append(name).Append("=").Append(queryString[name]);
+                protectedQueryString.Append(name).Append("=").Append(HttpUtility.UrlEncode(queryString[name]));
             }
 
             // Determine what the hash SHOULD be

--- a/build.pipeline.yml
+++ b/build.pipeline.yml
@@ -32,6 +32,8 @@ steps:
   - template: ./file_system_debug.steps.yml@tpr_pipeline_snippets
 
   - template: git-secrets.steps.yml@hooks
+    parameters:
+      repoPath: $(Build.SourcesDirectory)\url-protection
 
   - task: DotNetCoreCLI@2
     inputs:


### PR DESCRIPTION
AB#143022